### PR TITLE
Enforce consistent state name returns in map_query tests

### DIFF
--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -3,7 +3,6 @@ import unittest
 
 import numpy as np
 import numpy.testing as np_test
-from pgmpy.utils import get_example_model
 
 from pgmpy.factors.continuous import LinearGaussianCPD
 from pgmpy.factors.discrete import DiscreteFactor, TabularCPD
@@ -17,6 +16,7 @@ from pgmpy.models import (
     JunctionTree,
     LinearGaussianBayesianNetwork,
 )
+from pgmpy.utils import get_example_model
 
 
 class TestVariableElimination(unittest.TestCase):
@@ -558,11 +558,11 @@ class TestSnowNetwork(unittest.TestCase):
                 )
                 np_test.assert_array_almost_equal(query4.values, [0.34375, 0.65625])
 
-                # TODO: State name should be returned here.
+                # State name should be returned here.
                 map4 = infer.map_query(
                     ["Traffic"], virtual_evidence=[virt_evidence], show_progress=False
                 )
-                self.assertTrue(map4 in [{"Traffic": "slow"}, {"Traffic": 1}])
+                self.assertEqual(map4, {"Traffic": "slow"})
 
         virt_evidence1_cpd = TabularCPD(
             "Risk", 2, [[0.7], [0.3]], state_names={"Risk": ["yes", "no"]}

--- a/pgmpy/tests/test_inference/test_ExactInferenceTorch.py
+++ b/pgmpy/tests/test_inference/test_ExactInferenceTorch.py
@@ -551,11 +551,11 @@ class TestSnowNetworkTorch(unittest.TestCase):
                 compat_fns.to_numpy(query4.values), [0.34375, 0.65625]
             )
 
-            # TODO: State name should be returned here.
+            # State name should be returned here.
             map4 = infer.map_query(
                 ["Traffic"], virtual_evidence=[virt_evidence], show_progress=False
             )
-            self.assertTrue(map4 in [{"Traffic": "slow"}, {"Traffic": 1}])
+            self.assertEqual(map4, {"Traffic": "slow"})
 
         virt_evidence1 = TabularCPD(
             "Risk", 2, [[0.7], [0.3]], state_names={"Risk": ["yes", "no"]}


### PR DESCRIPTION
- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [X] Check the commit's or even all commits' message styles matches our requested structure.

### List of changes to the codebase in this pull request
- This PR fixes an inconsistency in test expectations for the `map_query` method. The tests now properly assert that state names (rather than numeric indices) are returned in query results.
